### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is automatically generated using
+[git-cliff](https://git-cliff.org/) from commit messages following
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+View [unreleased changes][unreleased] since the last release.
+
+## [0.1.0] <a name="0.1.0" href="#0.1.0">-</a> February 12, 2026
+
+### 🚀 Features
+
+- Initialize project (#1) by [@jmlopez-rod](https://github.com/jmlopez-rod) in
+  [#1](https://github.com/hotdog-werx/uv-toolbox/pull/1)
+- Initial implementation (#2) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#2](https://github.com/hotdog-werx/uv-toolbox/pull/2)
+
+### ⚙️ Miscellaneous Tasks
+
+- Bump mise tool versions by
+  [@jamestrousdale](https://github.com/jamestrousdale)
+- Switch to uv build backend by
+  [@jamestrousdale](https://github.com/jamestrousdale)
+- Fix readme badge by [@jamestrousdale](https://github.com/jamestrousdale)
+- Add CHANGELOG.md by [@jamestrousdale](https://github.com/jamestrousdale)
+
+[0.1.0]: https://github.com/hotdog-werx/uv-toolbox/tree/0.1.0


### PR DESCRIPTION
## [0.1.0] <a name="0.1.0" href="#0.1.0">-</a> February 12, 2026
### 🚀 Features
- Initialize project (#1) by [@jmlopez-rod](https://github.com/jmlopez-rod) in [#1](https://github.com/hotdog-werx/uv-toolbox/pull/1)
- Initial implementation (#2) by [@jamestrousdale](https://github.com/jamestrousdale) in [#2](https://github.com/hotdog-werx/uv-toolbox/pull/2)
### ⚙️ Miscellaneous Tasks
- Bump mise tool versions by [@jamestrousdale](https://github.com/jamestrousdale)
- Switch to uv build backend by [@jamestrousdale](https://github.com/jamestrousdale)
- Fix readme badge by [@jamestrousdale](https://github.com/jamestrousdale)
- Add CHANGELOG.md by [@jamestrousdale](https://github.com/jamestrousdale)

[0.1.0]: https://github.com/hotdog-werx/uv-toolbox/tree/0.1.0
